### PR TITLE
Further ignore tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 .*.swp
-.*~
+*~
+*.bk
 /Cargo.lock


### PR DESCRIPTION
rustfmt makes .bk files.
~ files are not always . prefixed.
