### PR TITLE
Adds support for declaring IFA_ADDRESS/LOCAL individually 

### DIFF
--- a/src/packet/route/addr.rs
+++ b/src/packet/route/addr.rs
@@ -14,7 +14,7 @@ use pnet::util::MacAddr;
 use libc;
 use std::io::{Read,Write,Cursor,self};
 use byteorder::{LittleEndian, BigEndian, ReadBytesExt};
-use std::net::{Ipv4Addr,Ipv6Addr};
+use std::net::{Ipv4Addr,Ipv6Addr, IpAddr};
 
 pub const RTM_NEWADDR: u16 = 20;
 pub const RTM_DELADDR: u16 = 21;
@@ -106,14 +106,11 @@ impl<R: Read> Iterator for AddrsIterator<R> {
     }
 }
 
-/// Abstract over IP versions
-#[derive(Eq,PartialEq)]
-pub enum IpAddr {
-    V4(Ipv4Addr),
-    V6(Ipv6Addr),
+trait ToByteVec {
+    fn bytes(&self) -> Vec<u8>;
 }
 
-impl IpAddr {
+impl ToByteVec for IpAddr {
     fn bytes(&self) -> Vec<u8> {
         match self {
             &IpAddr::V4(ip) => {
@@ -122,29 +119,10 @@ impl IpAddr {
                 v
             },
             &IpAddr::V6(ip) => {
-                panic!("not implemented"); /* FIXME */
+                let mut v = Vec::new();
+                v.extend_from_slice(&ip.octets()[..]);
+                v
             }
-        }
-    }
-}
-
-impl From<Ipv6Addr> for IpAddr {
-    fn from(addr: Ipv6Addr) -> Self {
-        IpAddr::V6(addr)
-    }
-}
-
-impl From<Ipv4Addr> for IpAddr {
-    fn from(addr: Ipv4Addr) -> Self {
-        IpAddr::V4(addr)
-    }
-}
-
-impl ::std::fmt::Debug for IpAddr {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        match self {
-            &IpAddr::V4(ip) => ip.fmt(f),
-            &IpAddr::V6(ip) => ip.fmt(f),
         }
     }
 }

--- a/src/packet/route/addr.rs
+++ b/src/packet/route/addr.rs
@@ -33,7 +33,7 @@ pub const RTM_GETADDR: u16 = 22;
 #[derive(Debug,Copy,Clone)]
 #[repr(u8)]
 pub enum Scope {
-    Global=0,
+    Universe=0,
     /* User defined values  */
     Site=200,
     Link=253,

--- a/src/packet/route/link.rs
+++ b/src/packet/route/link.rs
@@ -519,7 +519,7 @@ impl Link {
     }
 }
 
-struct IfInfoPacketBuilder {
+pub struct IfInfoPacketBuilder {
     data: Vec<u8>,
 }
 

--- a/src/packet/route/mod.rs
+++ b/src/packet/route/mod.rs
@@ -34,7 +34,7 @@ pub struct RtAttrIterator<'a> {
 }
 
 impl<'a> RtAttrIterator<'a> {
-    fn new(buf: &'a [u8]) -> Self {
+    pub fn new(buf: &'a [u8]) -> Self {
         RtAttrIterator {
             buf: buf,
         }

--- a/src/packet/route/neighbour.rs
+++ b/src/packet/route/neighbour.rs
@@ -2,6 +2,7 @@
 use libc;
 use std::io::{self, Read, Write};
 use std::mem;
+use std::net::IpAddr;
 
 use byteorder::{ByteOrder, NativeEndian};
 
@@ -15,7 +16,6 @@ use packet::netlink::{NLMSG_NOOP, NLMSG_ERROR, NLMSG_DONE, NLMSG_OVERRUN};
 use packet::netlink::{NetlinkBufIterator, NetlinkReader, NetlinkRequestBuilder};
 use ::socket::{NetlinkSocket, NetlinkProtocol};
 use packet::netlink::NetlinkConnection;
-use packet::route::addr::IpAddr;
 use pnet::packet::MutablePacket;
 use pnet::packet::Packet;
 use pnet::packet::PacketSize;


### PR DESCRIPTION
This pr also makes IfInfoPacketBuilder public. This struct is useful for building info package and should not be hidden. The same applies to the RtAttrIterator::new function. 