### PR TITLE
Fixes bug with wrong endianess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,26 +8,16 @@ repository = "https://github.com/polachok/pnetlink"
 readme = "README.md"
 keywords = ["netlink", "pnet", "linux", "network"]
 license = "MIT"
-documentation = "https://docs.rs/pnetlink/0.0.2/pnetlink/"
-
-[build-dependencies.pnet_macros]
-version = "0.13"
-features = [ "with-syntex" ]
-
-[dependencies.pnet_macros_support]
-version = "0.1.1"
-
-[dependencies.pnet]
-version = "0.16"
-features = [ "with-syntex" ]
-
-[build-dependencies.syntex]
-version = "0.42"
-
-[dependencies]
-libc = "0.2"
+documentation = "https://docs.rs/pnetlink/"
 
 [dependencies]
 rand = "0.3.14"
 bitflags = "0.7"
 byteorder = "0.5.3"
+libc = "0.2"
+pnet = "0.20"
+pnet_macros_support = "0.20"
+
+[build-dependencies]
+pnet_macros = "0.20"
+syntex = "0.42"

--- a/build.rs
+++ b/build.rs
@@ -1,25 +1,22 @@
-extern crate syntex;
 extern crate pnet_macros;
+extern crate syntex;
 
 use std::env;
 use std::path::Path;
 use std::fs;
 
-const FILES: &'static [&'static str] = &[
-    "netlink.rs",
-    "route/route.rs",
-    "audit/audit.rs"
-];
+const FILES: &'static [&'static str] = &["netlink.rs", "route/route.rs", "audit/audit.rs"];
 
-pub fn expand() {
+fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
 
     for file in FILES {
         let src_file = format!("src/packet/{}.in", file);
         let src = Path::new(&src_file);
+
         let dst_name = Path::new(file);
         if let Some(parent) = dst_name.parent() {
-            fs::create_dir(Path::new(&out_dir).join(parent));
+            let _ = fs::create_dir(Path::new(&out_dir).join(parent));
         }
         let dst = Path::new(&out_dir).join(dst_name);
 
@@ -28,8 +25,4 @@ pub fn expand() {
 
         registry.expand("", &src, &dst).unwrap();
     }
-}
-
-fn main() {
-    expand();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! `socket` module can be used to establish Netlink socket
 //! `packet` contains high level functions and traits
 #[macro_use]
-extern crate bitflags; 
+extern crate bitflags;
 extern crate pnet;
 extern crate pnet_macros_support;
 extern crate libc;

--- a/src/packet/audit/audit.rs.in
+++ b/src/packet/audit/audit.rs.in
@@ -3,16 +3,16 @@ use pnet::packet::PrimitiveValues;
 
 #[packet]
 pub struct AuditStatus {
-    mask: u32le,
-    enabled: u32le,
-    failure: u32le,
-    pid: u32le,
-    rate_limit: u32le,
-    backlog_limit: u32le,
-    lost: u32le,
-    backlog: u32le,
-    feature_bitmap: u32le,
-    backlog_wait_time: u32le,
+    mask: u32he,
+    enabled: u32he,
+    failure: u32he,
+    pid: u32he,
+    rate_limit: u32he,
+    backlog_limit: u32he,
+    lost: u32he,
+    backlog: u32he,
+    feature_bitmap: u32he,
+    backlog_wait_time: u32he,
     #[payload]
     #[length="0"]
     _zero: Vec<u8>,

--- a/src/packet/netlink.rs.in
+++ b/src/packet/netlink.rs.in
@@ -3,12 +3,11 @@ use pnet::packet::PrimitiveValues;
 
 #[packet]
 pub struct Netlink {
-    length: u32le,
-    kind: u16le, // NOOP | ERROR | DONE | OVERRUN
-    #[construct_with(u16le)]
-    flags: NetlinkMsgFlags,
-    seq: u32le,
-    pid: u32le,
+    length: u32he,
+    kind: u16he, // NOOP | ERROR | DONE | OVERRUN
+    #[construct_with(u16le)] flags: NetlinkMsgFlags,
+    seq: u32he,
+    pid: u32he,
     #[payload]
     #[length_fn = "payload_length"]
     payload: Vec<u8>,
@@ -16,9 +15,8 @@ pub struct Netlink {
 
 #[packet]
 pub struct NetlinkError {
-    error: u32le, // must be i32le
-    #[payload]
-    payload: Vec<u8>,
+    error: u32he, // must be i32he
+    #[payload] payload: Vec<u8>,
 }
 
 impl PrimitiveValues for NetlinkMsgFlags {

--- a/src/packet/route/route.rs.in
+++ b/src/packet/route/route.rs.in
@@ -64,10 +64,10 @@ pub struct IfAddr {
 /* IfAddr cache_info struct */
 #[packet]
 pub struct IfAddrCacheInfo {
-    ifa_prefered: u32le,
-    ifa_valid: u32le,
-    created: u32le, /* created timestamp, hundredths of seconds */
-    updated: u32le, /* updated timestamp, hundredths of seconds */
+    ifa_prefered: u32he,
+    ifa_valid: u32he,
+    created: u32he, /* created timestamp, hundredths of seconds */
+    updated: u32he, /* updated timestamp, hundredths of seconds */
     #[payload]
     #[length="0"]
     payload: Vec<u8>,
@@ -77,8 +77,8 @@ pub struct IfAddrCacheInfo {
 pub struct NeighbourDiscovery {
     family: u8,
     pad1: u8,
-    pad2: u16le,
-    ifindex: u32le, // Should be i32le, not implemented?
+    pad2: u16he,
+    ifindex: u32he, // Should be i32he, not implemented?
     #[construct_with(u16le)]
     state: NeighbourState,
     #[construct_with(u8)]
@@ -114,7 +114,7 @@ pub struct RtMsg {
     #[construct_with(u8)]
     rtm_scope: Scope,
 
-    rtm_flags: u32le,
+    rtm_flags: u32he,
     _padding: u8,
     #[payload]
     payload: Vec<u8>,
@@ -123,14 +123,14 @@ pub struct RtMsg {
 /* rta_cacheinfo: linux/rtnetlink.h */
 #[packet]
 pub struct RouteCacheInfo {
-    rta_clntref: u32le,
-    rta_lastuse: u32le,
-    rta_expires: u32le,
-    rta_error: u32le,
-    rta_used: u32le,
-    rta_id: u32le,
-    rta_ts: u32le,
-    rta_tsusage: u32le,
+    rta_clntref: u32he,
+    rta_lastuse: u32he,
+    rta_expires: u32he,
+    rta_error: u32he,
+    rta_used: u32he,
+    rta_id: u32he,
+    rta_ts: u32he,
+    rta_tsusage: u32he,
     #[payload]
     #[length="0"]
     payload: Vec<u8>,
@@ -155,8 +155,8 @@ pub struct FibRule {
 
 #[packet]
 pub struct RtAttr {
-    rta_len: u16le,
-    rta_type: u16le,
+    rta_len: u16he,
+    rta_type: u16he,
     #[payload]
     #[length_fn = "rtattr_len"]
     payload: Vec<u8>,
@@ -168,9 +168,9 @@ fn rtattr_len(pkt: &RtAttrPacket) -> usize {
 
 #[packet]
 pub struct RtAttrMtu {
-    rta_len: u16le,
-    rta_type: u16le,
-    mtu: u32le,
+    rta_len: u16he,
+    rta_type: u16he,
+    mtu: u32he,
     #[payload]
     #[length = "0"]
     _payload: Vec<u8>,


### PR DESCRIPTION
Netlink packages are always in the same endianess as the host system.
libpnet does not support to create packages with data types that are bigger than
u8 without a fixed endianess. So, we create two different files, one for big
and one for little endian.

This solution is only a "hack", it would be nice if libpnet would support adding "normal" data types. 