### PR TITLE
Notes on the state of the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 pnetlink - native [NetLink](https://en.wikipedia.org/wiki/Netlink) library for rust using libpnet
+
+## Building
+
+The project builds fine with `cargo build`.
+
+The tests are not thread safe. You must run `cargo test -- --test-threads=1`,
+or you will get many `AddrInUse` errors.
+
+Some of the tests require elevated permissions; either capabilities granted
+to the test binary, or for the test procedure to run as `root`. These will
+fail with a `PermissionDenied` error.
+

--- a/src/packet/netlink.rs
+++ b/src/packet/netlink.rs
@@ -92,6 +92,7 @@ fn read_ip_link_dump_2() {
     }
 }
 
+#[ignore]
 #[test]
 fn read_ip_link_sock() {
     use std::fs::File;


### PR DESCRIPTION
The tests aren't a great experience for someone downloading this codebase.

This commit adds:
 * a note to the README about what the errors mean
 * an ignore on a test that hangs forever on purpose

It doesn't fix two outstanding tests, which attempt to read a file named `dumps/ip_link.bin`, which appears to have not been committed? Could that please be rectified, or those tests removed?