### PR TITLE
Update all the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/pnetlink/"
 
 [dependencies]
 rand = "0.4"
-bitflags = "0.7"
+bitflags = "1"
 byteorder = "1"
 libc = "0.2"
 pnet = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ license = "MIT"
 documentation = "https://docs.rs/pnetlink/"
 
 [dependencies]
-rand = "0.3.14"
+rand = "0.4"
 bitflags = "0.7"
-byteorder = "0.5.3"
+byteorder = "1"
 libc = "0.2"
-pnet = "0.20"
-pnet_macros_support = "0.20"
+pnet = "0.21"
+pnet_macros_support = "0.21"
 
 [build-dependencies]
-pnet_macros = "0.20"
+pnet_macros = "0.21"
 syntex = "0.42"

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,6 @@ const FILES: &'static [&'static str] = &["netlink.rs", "route/route.rs", "audit/
 
 fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
-
     for file in FILES {
         let src_file = format!("src/packet/{}.in", file);
         let src = Path::new(&src_file);

--- a/examples/ip_neigh.rs
+++ b/examples/ip_neigh.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use pnetlink::packet::netlink::NetlinkConnection;
 use pnetlink::packet::route::link::{Links, Link};
-use pnetlink::packet::route::neighbour::{Neighbour, Neighbours, NOARP};
+use pnetlink::packet::route::neighbour::{Neighbour, Neighbours, NeighbourState};
 
 fn main() {
     let mut conn = NetlinkConnection::new();
@@ -12,7 +12,7 @@ fn main() {
         conn.iter_links().unwrap().map(|link| (link.get_index(), link)).collect::<HashMap<_, _>>();
     let neighbours = conn.iter_neighbours(None).unwrap().collect::<Vec<_>>();
     for neighbour in neighbours {
-        if neighbour.get_state() == NOARP {
+        if neighbour.get_state() == NeighbourState::NOARP {
             continue;
         }
         let ifindex = neighbour.get_ifindex();

--- a/src/packet/audit/mod.rs
+++ b/src/packet/audit/mod.rs
@@ -1,6 +1,5 @@
 use packet::netlink::{MutableNetlinkPacket,NetlinkPacket};
-use packet::netlink::{NLM_F_ACK, NLM_F_REQUEST, NLM_F_DUMP};
-use packet::netlink::{NLMSG_NOOP,NLMSG_ERROR,NLMSG_DONE,NLMSG_OVERRUN};
+use packet::netlink::NetlinkMsgFlags;
 use packet::netlink::{NetlinkBufIterator,NetlinkReader,NetlinkRequestBuilder};
 use ::socket::{NetlinkSocket,NetlinkProtocol};
 use packet::netlink::NetlinkConnection;
@@ -19,7 +18,7 @@ pub trait Audit where Self: Read + Write {
 impl Audit for NetlinkConnection {
     fn audit_enable<'a>(&'a mut self) -> ::std::io::Result<()> {
         let mut buf = vec![0; MutableAuditStatusPacket::minimum_packet_size()];
-        let req = NetlinkRequestBuilder::new(1001, NLM_F_REQUEST | NLM_F_ACK)
+        let req = NetlinkRequestBuilder::new(1001, NetlinkMsgFlags::NLM_F_REQUEST | NetlinkMsgFlags::NLM_F_ACK)
             .append({
                 let mut status = MutableAuditStatusPacket::new(&mut buf).unwrap();
                 status.set_mask(1);

--- a/src/packet/netlink.rs
+++ b/src/packet/netlink.rs
@@ -9,29 +9,29 @@ use pnet::packet::{Packet,PacketSize,FromPacket};
 include!(concat!(env!("OUT_DIR"), "/netlink.rs"));
 
 bitflags! {
-    pub flags NetlinkMsgFlags: u16 {
+    pub struct NetlinkMsgFlags: u16 {
         /* It is request message. 	*/
-        const NLM_F_REQUEST = 1,
+        const NLM_F_REQUEST = 1;
         /* Multipart message, terminated by NLMSG_DONE */
-        const NLM_F_MULTI = 2,
+        const NLM_F_MULTI = 2;
         /* Reply with ack, with zero or error code */
-        const NLM_F_ACK = 4,
+        const NLM_F_ACK = 4;
         /* Echo this request 		*/
-        const NLM_F_ECHO = 8,
+        const NLM_F_ECHO = 8;
         /* Dump was inconsistent due to sequence change */
-        const NLM_F_DUMP_INTR = 16,
+        const NLM_F_DUMP_INTR = 16;
 
         /* Modifiers to GET request */
-        const NLM_F_ROOT =	0x100,	/* specify tree	root	*/
-        const NLM_F_MATCH = 0x200,	/* return all matching	*/
-        const NLM_F_ATOMIC = 0x400,	/* atomic GET		*/
-        const NLM_F_DUMP =	(NLM_F_ROOT.bits|NLM_F_MATCH.bits),
+        const NLM_F_ROOT =	0x100;	/* specify tree	root	*/
+        const NLM_F_MATCH = 0x200;	/* return all matching	*/
+        const NLM_F_ATOMIC = 0x400;	/* atomic GET		*/
+        const NLM_F_DUMP =	(Self::NLM_F_ROOT.bits | Self::NLM_F_MATCH.bits);
 
         /* Modifiers to NEW request */
-        const NLM_F_REPLACE = 0x100,   /* Override existing            */
-        const NLM_F_EXCL =    0x200,   /* Do not touch, if it exists   */
-        const NLM_F_CREATE =  0x400,   /* Create, if it does not exist */
-        const NLM_F_APPEND =  0x800,   /* Add to end of list           */
+        const NLM_F_REPLACE = 0x100;   /* Override existing            */
+        const NLM_F_EXCL =    0x200;   /* Do not touch, if it exists   */
+        const NLM_F_CREATE =  0x400;   /* Create, if it does not exist */
+        const NLM_F_APPEND =  0x800;   /* Add to end of list           */
     }
 }
 
@@ -282,7 +282,7 @@ impl NetlinkRequestBuilder {
             let mut pkt = MutableNetlinkPacket::new(&mut data).unwrap();
             pkt.set_length(len as u32);
             pkt.set_kind(kind);
-            pkt.set_flags(flags | NLM_F_REQUEST);
+            pkt.set_flags(flags | NetlinkMsgFlags::NLM_F_REQUEST);
         }
         NetlinkRequestBuilder {
             data: data,

--- a/src/packet/route/neighbour.rs
+++ b/src/packet/route/neighbour.rs
@@ -11,8 +11,7 @@ use packet::route::{NeighbourDiscoveryPacket, MutableNeighbourDiscoveryPacket, R
                     RtAttrPacket, MutableRtAttrPacket, RtAttrMtuPacket};
 use packet::route::link::Link;
 use packet::netlink::{MutableNetlinkPacket, NetlinkPacket, NetlinkErrorPacket};
-use packet::netlink::{NLM_F_ACK, NLM_F_REQUEST, NLM_F_DUMP, NLM_F_MATCH, NLM_F_EXCL, NLM_F_CREATE};
-use packet::netlink::{NLMSG_NOOP, NLMSG_ERROR, NLMSG_DONE, NLMSG_OVERRUN};
+use packet::netlink::NetlinkMsgFlags;
 use packet::netlink::{NetlinkBufIterator, NetlinkReader, NetlinkRequestBuilder};
 use ::socket::{NetlinkSocket, NetlinkProtocol};
 use packet::netlink::NetlinkConnection;
@@ -83,18 +82,18 @@ pub enum LinkType {
 
 // neighbour states
 bitflags! {
-    pub flags NeighbourState: u16 {
-        const INCOMPLETE =  0x1,    /* Still attempting to resolve. */
-        const REACHABLE  =  0x2,    /* A confirmed working cache entry. */
-        const STALE      =  0x4,    /* an expired cache entry. */
-        const DELAY      =  0x8,    /* Neighbor no longer reachable.
+    pub struct NeighbourState: u16 {
+        const INCOMPLETE =  0x1;    /* Still attempting to resolve. */
+        const REACHABLE  =  0x2;    /* A confirmed working cache entry. */
+        const STALE      =  0x4;    /* an expired cache entry. */
+        const DELAY      =  0x8;    /* Neighbor no longer reachable.
                                        Traffic sent, waiting for confirmation. */
-        const PROBE      = 0x10,    /* A cache entry that is currently
+        const PROBE      = 0x10;    /* A cache entry that is currently
                                        being re-solicited.*/
-        const FAILED     = 0x20,    /* An invalid cache entry. */
+        const FAILED     = 0x20;    /* An invalid cache entry. */
         /* Dummy states */
-        const NOARP      = 0x40,    /* A device that does not do neighbour discovery */
-        const PERMANENT  = 0x80,    /* Permanently set entries */
+        const NOARP      = 0x40;    /* A device that does not do neighbour discovery */
+        const PERMANENT  = 0x80;    /* Permanently set entries */
     }
 }
 
@@ -106,13 +105,13 @@ impl NeighbourState {
 
 // neighbour flags
 bitflags! {
-    pub flags NeighbourFlags: u8 {
-        const USE         =  0x1,
-        const SELF        =  0x2,
-        const MASTER      =  0x4,
-        const PROXY       =  0x8,
-        const EXT_LEARNED = 0x10,
-        const ROUTER      = 0x80,
+    pub struct NeighbourFlags: u8 {
+        const USE         =  0x1;
+        const SELF        =  0x2;
+        const MASTER      =  0x4;
+        const PROXY       =  0x8;
+        const EXT_LEARNED = 0x10;
+        const ROUTER      = 0x80;
     }
 }
 
@@ -229,7 +228,7 @@ impl Neighbours for NetlinkConnection {
         // NB: This should be a IfInfoPacket because - well see rtnetlink.c in Linux - but they pun
         // successfully.
         //
-        let req = NetlinkRequestBuilder::new(RTM_GETNEIGH, NLM_F_DUMP)
+        let req = NetlinkRequestBuilder::new(RTM_GETNEIGH, NetlinkMsgFlags::NLM_F_DUMP)
             .append(match link {
                     Some(link) => {
                         NeighbourDiscoveryPacketBuilder::new().set_ifindex(link.get_index())

--- a/src/packet/route/route.rs
+++ b/src/packet/route/route.rs
@@ -2,8 +2,7 @@
 use packet::route::{RouteCacheInfoPacket, RtMsgPacket, MutableIfInfoPacket, IfInfoPacket,
                     RtAttrIterator, RtAttrPacket, MutableRtAttrPacket};
 use packet::netlink::NetlinkPacket;
-use packet::netlink::{NLM_F_DUMP, NLM_F_MATCH, NLM_F_EXCL, NLM_F_CREATE};
-use packet::netlink::{NLMSG_ERROR, NLMSG_DONE, NLMSG_OVERRUN};
+use packet::netlink::NetlinkMsgFlags;
 use packet::netlink::{NetlinkBufIterator, NetlinkReader, NetlinkRequestBuilder};
 use packet::netlink::NetlinkConnection;
 use pnet::packet::MutablePacket;
@@ -45,11 +44,11 @@ enum RtmType {
 }
 
 bitflags! {
-    pub flags RtmFlags: u8 {
-        const NOTIFY = 0x100,
-        const CLONED = 0x200,
-        const EQUALIZE = 0x400,
-        const PREFIX = 0x800,
+    pub struct RtmFlags: u8 {
+        const NOTIFY = 0x100;
+        const CLONED = 0x200;
+        const EQUALIZE = 0x400;
+        const PREFIX = 0x800;
     }
 }
 
@@ -86,7 +85,7 @@ impl Route {
     /// Iterate over routes
     pub fn iter_routes(conn: &mut NetlinkConnection) -> RoutesIterator<&mut NetlinkConnection> {
         let mut buf = vec![0; MutableIfInfoPacket::minimum_packet_size()];
-        let req = NetlinkRequestBuilder::new(RTM_GETROUTE, NLM_F_DUMP)
+        let req = NetlinkRequestBuilder::new(RTM_GETROUTE, NetlinkMsgFlags::NLM_F_DUMP)
             .append({
                 let mut ifinfo = MutableIfInfoPacket::new(&mut buf).unwrap();
                 ifinfo.set_family(0 /* AF_UNSPEC */);

--- a/src/packet/route/rule.rs
+++ b/src/packet/route/rule.rs
@@ -2,8 +2,7 @@
 use packet::route::{FibRulePacket,MutableRtMsgPacket,MutableIfInfoPacket,RtAttrIterator,RtAttrPacket,MutableRtAttrPacket};
 use packet::route::link::Link;
 use packet::netlink::{MutableNetlinkPacket,NetlinkPacket,NetlinkErrorPacket};
-use packet::netlink::{NLM_F_ACK,NLM_F_REQUEST,NLM_F_DUMP,NLM_F_MATCH,NLM_F_EXCL,NLM_F_CREATE};
-use packet::netlink::{NLMSG_NOOP,NLMSG_ERROR,NLMSG_DONE,NLMSG_OVERRUN};
+use packet::netlink::NetlinkMsgFlags;
 use packet::netlink::{NetlinkBufIterator,NetlinkReader,NetlinkRequestBuilder};
 use socket::{NetlinkSocket,NetlinkProtocol};
 use packet::netlink::NetlinkConnection;
@@ -49,7 +48,7 @@ impl Rule {
     /// iterate over rules
     pub fn iter_rules(conn: &mut NetlinkConnection) -> RulesIterator<&mut NetlinkConnection> {
         let mut buf = vec![0; MutableIfInfoPacket::minimum_packet_size()];
-        let req = NetlinkRequestBuilder::new(RTM_GETRULE, NLM_F_DUMP)
+        let req = NetlinkRequestBuilder::new(RTM_GETRULE, NetlinkMsgFlags::NLM_F_DUMP)
             .append({
                 let mut ifinfo = MutableIfInfoPacket::new(&mut buf).unwrap();
                 ifinfo.set_family(0 /* AF_UNSPEC */);


### PR DESCRIPTION
Updating `pnet` is necessary right now, as old `pnet` doesn't build with crates.io in its current state, but this is probably a bug that `pnet` will resolve.

`bitflags` has moved to using associated consts, which is a bit of a nightmare change (only find and replace, though). It is better. Everything else was easy.

`syntex` can't be updated without breaking `pnet`.