### PR TITLE
Allow blocking socket to be created

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -67,6 +67,11 @@ impl Drop for NetlinkSocket {
 
 impl NetlinkSocket {
 	pub fn bind(proto: NetlinkProtocol, groups: u32) -> Result<NetlinkSocket> {
+		let nonblocking = true;
+		NetlinkSocket::bind_with_args(proto, groups, nonblocking)
+	}
+
+	pub fn bind_with_args(proto: NetlinkProtocol, groups: u32, nonblocking: bool) -> Result<NetlinkSocket> {
 		use std::mem::size_of;
 		use std::mem::transmute;
 		use libc::getpid;
@@ -79,7 +84,7 @@ impl NetlinkSocket {
 		}
 		let sock = NetlinkSocket { fd: res };
 
-		let mut nonblocking = 1 as libc::c_ulong;
+		let mut nonblocking = if nonblocking { 1 } else { 0 } as libc::c_ulong;
 		res = unsafe {
 			libc::ioctl(sock.fd, libc::FIONBIO, &mut nonblocking)
 		};


### PR DESCRIPTION
Allow receiving route events:

let group = MulticastGroup::RTMGRP_LINK
    | MulticastGroup::RTMGRP_IPV4_IFADDR
    | MulticastGroup::RTMGRP_IPV6_IFADDR;

let nonblocking = false;
let mut socket =
    NetlinkSocket::bind_with_args(NetlinkProtocol::Route, group.bits(),
nonblocking)?;